### PR TITLE
Allows users to add custom illegal charaters and strings for filenames

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Notice, Plugin, PluginSettingTab, Setting, EventRef, MarkdownView, TAbstractFile} from 'obsidian';
+import { App, Modal, Notice, Plugin, PluginSettingTab, Setting, EventRef, MarkdownView, TFile, TAbstractFile} from 'obsidian';
 
 const stockIllegalSymbols = ['*', '\\', '/', '<', '>', ':', '|', '?'];
 
@@ -26,7 +26,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 		await this.loadSettings();
 		
 		this.registerEvent(
-			this.app.vault.on('rename', (file, oldPath) => this.handleSyncFilenameToHeading(file, oldPath)),
+			this.app.vault.on('rename', (file, oldPath) => this.handleSyncFilenameToHeading(file, oldPath))
 		);
 		this.registerEvent(this.app.vault.on('modify', (file) => this.handleSyncHeadingToFile(file)));
 		this.registerEvent(
@@ -53,6 +53,10 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 	}
 
 	handleSyncHeadingToFile(file: TAbstractFile) {
+		if (!(file instanceof TFile)) {
+			console.log("Here")
+			return;
+		}
 		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
 
 		// if ignored, just bail
@@ -85,6 +89,10 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 	}
 
 	handleSyncFilenameToHeading(file: TAbstractFile, oldPath: string) {
+		if (!(file instanceof TFile)) {
+			console.log("Here")
+			return;
+		}
 		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
 
 		// if oldpath is ignored, hook in and update the new filepath to be ignored instead
@@ -113,7 +121,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 		const cursor = doc.getCursor();
 
 		const foundHeading = this.findHeading(doc);
-		const sanitizedHeading = this.sanitizeHeading(file.name.split('.').slice(0, -1).join('.')); //Removes extension
+		const sanitizedHeading = this.sanitizeHeading(file.basename); 
 		
 		if (foundHeading !== null) {
 			if (this.sanitizeHeading(foundHeading.Text) !== sanitizedHeading) {

--- a/main.ts
+++ b/main.ts
@@ -54,21 +54,12 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 
 	handleSyncHeadingToFile(file: TAbstractFile) {
 		if (!(file instanceof TFile)) {
-			console.log("Here")
 			return;
 		}
 		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
 
 		// if ignored, just bail
 		if (this.settings.ignoredFiles[file.path] !== undefined) {
-			return;
-		}
-
-		if (view === null) {
-			return;
-		}
-
-		if (view.file !== file) {
 			return;
 		}
 
@@ -105,14 +96,6 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 			delete this.settings.ignoredFiles[oldPath];
 			this.settings.ignoredFiles[file.path] = null;
 			this.saveSettings();
-			return;
-		}
-
-		if (view === null) {
-			return;
-		}
-
-		if (view.file !== file) {
 			return;
 		}
 

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,6 @@
 import { App, Modal, Notice, Plugin, PluginSettingTab, Setting, EventRef, MarkdownView, TAbstractFile} from 'obsidian';
 
 const stockIllegalSymbols = ['*', '\\', '/', '<', '>', ':', '|', '?'];
-let combinedIllegalSymbols: string[];
 
 interface LinePointer {
 	LineNumber: number;
@@ -147,7 +146,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 	}
 
 	sanitizeHeading(text: string) {
-		combinedIllegalSymbols = [...stockIllegalSymbols, ...this.settings.userIllegalSymbols];
+		let combinedIllegalSymbols = [...stockIllegalSymbols, ...this.settings.userIllegalSymbols];
 		combinedIllegalSymbols.forEach((symbol) => {
 			text = text.replace(symbol, '');
 		});

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Modal, Notice, Plugin, PluginSettingTab, Setting, EventRef, MarkdownView, TAbstractFile } from 'obsidian';
+import { App, Modal, Notice, Plugin, PluginSettingTab, Setting, EventRef, MarkdownView, TAbstractFile} from 'obsidian';
 
 const stockIllegalSymbols = ['*', '\\', '/', '<', '>', ':', '|', '?'];
 let combinedIllegalSymbols: string[];
@@ -43,7 +43,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 				let leaf = this.app.workspace.activeLeaf;
 				if (leaf) {
 					if (!checking) {
-						this.settings.ignoredFiles[this.app.workspace.activeLeaf.view.file.path.trim()] = null;
+						this.settings.ignoredFiles[this.app.workspace.getActiveFile().path] = null;
 						this.saveSettings();
 					}
 					return true;
@@ -85,7 +85,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 		}
 	}
 
-	handleSyncFilenameToHeading(file, oldPath) {
+	handleSyncFilenameToHeading(file: TAbstractFile, oldPath: string) {
 		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
 
 		// if oldpath is ignored, hook in and update the new filepath to be ignored instead
@@ -114,7 +114,8 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 		const cursor = doc.getCursor();
 
 		const foundHeading = this.findHeading(doc);
-		const sanitizedHeading = this.sanitizeHeading(file.basename);
+		const sanitizedHeading = this.sanitizeHeading(file.name.split('.').slice(0, -1).join('.')); //Removes extension
+		
 		if (foundHeading !== null) {
 			if (this.sanitizeHeading(foundHeading.Text) !== sanitizedHeading) {
 				this.replaceLine(doc, foundHeading, `# ${sanitizedHeading}`);
@@ -147,7 +148,6 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 
 	sanitizeHeading(text: string) {
 		combinedIllegalSymbols = [...stockIllegalSymbols, ...this.settings.userIllegalSymbols];
-		console.log(combinedIllegalSymbols)
 		combinedIllegalSymbols.forEach((symbol) => {
 			text = text.replace(symbol, '');
 		});

--- a/main.ts
+++ b/main.ts
@@ -209,8 +209,8 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
 		);
 		
 		new Setting(containerEl)
-			.setName('Custom Illegal Charaters')
-			.setDesc('Type charaters seperated by a comma')
+			.setName('Custom Illegal Charaters/Strings')
+			.setDesc('Type charaters/strings seperated by a comma. This input is space sensitive.')
 			.addText((text) =>
 			text
 			  .setPlaceholder("[],#,...")


### PR DESCRIPTION
Based of issue #8, this feature adds a text box to the setting screen allowing users to input custom characters or strings. These will then be stripped from titles, like the default illegal character set. 

This branch also fixes a few typescript errors. So let me know if you would like me to create a pull request with just the fixes. 

Note: This is my first work with typescript/javascript and my first pull request so let me know if there is anything wrong or that can be improved. 