### PR TITLE
Allows user to decide if selected files are exclusively ignored or exclusively synced. 

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -56,23 +56,6 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 				return false;
 			},
 		});
-
-		this.addCommand({
-			id: 'page-heading-convert-to-selected',
-			name: 'Updates File Database to Version',
-			checkCallback: (checking: boolean) => {
-				let leaf = this.app.workspace.activeLeaf;
-				if (leaf) {
-					if (!checking) {
-						this.convertedIgnoredToSelected();
-						new Notice("Update Complete");
-					}
-					return true;
-				}
-				return false;
-			},
-		});
-		
 		this.convertedIgnoredToSelected();
 	}
 
@@ -80,7 +63,6 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 		//Converts ignores to selected files
 		for (const key in this.settings.ignoredFiles){
 			this.settings.selectedFiles[key] = true;
-			delete this.settings.ignoredFiles[key];
 		}
 		this.saveSettings();
 	}


### PR DESCRIPTION
Based on #6, this feature adds a toggle to allow users to select if the files in their selection will be exclusively ignored or exclusively synced. 

This feature does modify how the selectedFiles (previously ignoredFiles) works as null and undefined where being compared which typescript isn't a fan of. In order to ensure backward compatibility, a new data type was made and automatic conversion between the old type (ignoredFiles) and the new type (selectedFiles) happens. This is non-destructive. This could be expanded to have ignoredFiles and selectedFiles track each other to allow greater backwards compatibility. 