### PR TITLE
Fix the list of invalid characters being stripped

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,7 @@ import {
   Editor,
 } from 'obsidian';
 
-const stockIllegalSymbols = ['*', '\\', '/', '<', '>', ':', '|', '?'];
+const stockIllegalSymbols = ['\\', '/',  ':', '|', '#', '^', '[', ']'];
 
 interface LinePointer {
   lineNumber: number;

--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,7 @@ import {
   Editor,
 } from 'obsidian';
 
-const stockIllegalSymbols = ['\\', '/',  ':', '|', '#', '^', '[', ']'];
+const stockIllegalSymbols = ['\\', '/', ':', '|', '#', '^', '[', ']'];
 
 interface LinePointer {
   lineNumber: number;
@@ -342,12 +342,10 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
 
     containerEl.createEl('h2', { text: 'Filename Heading Sync' });
     containerEl.createEl('p', {
-      text:
-        'This plugin will overwrite the first heading found in a file with the filename.',
+      text: 'This plugin will overwrite the first heading found in a file with the filename.',
     });
     containerEl.createEl('p', {
-      text:
-        'If no header is found, will insert a new one at the first line (after frontmatter).',
+      text: 'If no header is found, will insert a new one at the first line (after frontmatter).',
     });
 
     new Setting(containerEl)
@@ -397,8 +395,7 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
 
     containerEl.createEl('h2', { text: 'Manually Ignored Files' });
     containerEl.createEl('p', {
-      text:
-        'You can ignore files from this plugin by using the "ignore this file" command',
+      text: 'You can ignore files from this plugin by using the "ignore this file" command',
     });
 
     // go over all ignored files and add them


### PR DESCRIPTION
Implements the #29 (https://github.com/dvcrn/obsidian-filename-heading-sync/issues/29).