### PR TITLE
add support for multiple illegal characters in heading

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,7 @@ import {
   Editor,
 } from 'obsidian';
 
-const stockIllegalSymbols = ['\\', '/', ':', '|', '#', '^', '[', ']'];
+const stockIllegalSymbols =  /[\\/:|#^[\]]/g;
 
 interface LinePointer {
   lineNumber: number;
@@ -229,11 +229,9 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
   }
 
   sanitizeHeading(text: string) {
-    let combinedIllegalSymbols = [
-      ...stockIllegalSymbols,
-      ...this.settings.userIllegalSymbols,
-    ];
-    combinedIllegalSymbols.forEach((symbol) => {
+    // stockIllegalSymbols is a regExp object, but userIllegalSymbols is a list of strings and therefore they are handled separately.
+    text = text.replace(stockIllegalSymbols, '');
+    this.settings.userIllegalSymbols.forEach(symbol => {
       text = text.replace(symbol, '');
     });
     return text.trim();


### PR DESCRIPTION
The `sanitizeHeading()` function was using `replace()` with a list of strings, but that only replaces the first instance of each illegal character.  This update changes the stockIllegalSymbols to a regExp object with a global flag so that all illegal characters are removed.  I don't know how to do the same thing with user defined symbols, so I left that one as it is.