### PR TITLE
Fix syncing when ancestors contain file basename

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -136,7 +136,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
         sanitizedHeading.length > 0 &&
         this.sanitizeHeading(file.basename) !== sanitizedHeading
       ) {
-        const newPath = file.path.replace(file.basename, sanitizedHeading);
+        const newPath = `${file.parent.path}/${sanitizedHeading}.md`;
         this.app.fileManager.renameFile(file, newPath);
       }
     });


### PR DESCRIPTION
Currently, renaming a file through the header fails when the current file basename is contained in the name of a parent folder. This is because replace replaces the first occurence, not the last. This can be seen if you try to update the title heading in a file located at `Tests/Test.md`.

This PR builds the path on top of the last parent instead of replacing. Since the path is normalized during rename, it's safe even if the file is in the base folder with a path of "/".