### PR TITLE
fix an error when closing the file

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -57,7 +57,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
 
     this.registerEvent(
       this.app.workspace.on('file-open', (file) => {
-        if (this.settings.useFileOpenHook) {
+        if (this.settings.useFileOpenHook && file !== null) {
           return this.handleSyncFilenameToHeading(file, file.path);
         }
       }),


### PR DESCRIPTION
It seems that Obsidian will trigger the event `file-open` with `null` when closing the file.

```
app.js:1 Uncaught TypeError: Cannot read properties of null (reading 'path')
    at eval (plugin:obsidian-filename-heading-sync:123:85)
    at t.e.tryTrigger (app.js:1:963725)
    at t.e.trigger (app.js:1:963658)
    at t.trigger (app.js:1:1520211)
    at t.activeLeafEvents (app.js:1:1510656)
    at a (app.js:1:264427)
```