### PR TITLE
Add support for underline style headings

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -14,8 +14,8 @@ const stockIllegalSymbols = /[\\/:|#^[\]]/g;
 
 // Must be Strings unless settings dialog is updated.
 const enum HeadingStyle {
-    Prefix = "Prefix",
-    Underline = "Underline",
+  Prefix = 'Prefix',
+  Underline = 'Underline',
 }
 
 interface LinePointer {
@@ -43,7 +43,7 @@ const DEFAULT_SETTINGS: FilenameHeadingSyncPluginSettings = {
   useFileSaveHook: true,
   newHeadingStyle: HeadingStyle.Prefix,
   replaceStyle: false,
-  underlineString: "===",
+  underlineString: '===',
 };
 
 export default class FilenameHeadingSyncPlugin extends Plugin {
@@ -284,13 +284,16 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
           style: HeadingStyle.Prefix,
         };
       } else {
-          if (fileLines[i+1] !== undefined && fileLines[i+1].match(/^=+$/) !== null) {
-            return {
-              lineNumber: i,
-              text: fileLines[i],
-              style: HeadingStyle.Underline,
-            }
-          }
+        if (
+          fileLines[i + 1] !== undefined &&
+          fileLines[i + 1].match(/^=+$/) !== null
+        ) {
+          return {
+            lineNumber: i,
+            text: fileLines[i],
+            style: HeadingStyle.Underline,
+          };
+        }
       }
     }
     return null; // no heading found
@@ -315,62 +318,52 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
     return text.trim();
   }
 
- /**
-  * Insert the `heading` at `lineNumber` in `file`.
-  *
-  * @param {TFile} file the file to modify
-  * @param {string[]} fileLines array of the file's contents, line by line
-  * @param {number} lineNumber zero-based index of the line to replace
-  * @param {string} text the new text
-  */
+  /**
+   * Insert the `heading` at `lineNumber` in `file`.
+   *
+   * @param {TFile} file the file to modify
+   * @param {string[]} fileLines array of the file's contents, line by line
+   * @param {number} lineNumber zero-based index of the line to replace
+   * @param {string} text the new text
+   */
   insertHeading(
     file: TFile,
     fileLines: string[],
     lineNumber: number,
     heading: string,
-  ){
+  ) {
     const newStyle = this.settings.newHeadingStyle;
     if (newStyle === HeadingStyle.Underline) {
-      this.insertLineInFile(
-        file,
-        fileLines,
-        lineNumber,
-        `${heading}`
-      );
+      this.insertLineInFile(file, fileLines, lineNumber, `${heading}`);
 
       this.insertLineInFile(
         file,
         fileLines,
-        lineNumber+1,
-        this.settings.underlineString
+        lineNumber + 1,
+        this.settings.underlineString,
       );
     } else {
-      this.insertLineInFile(
-        file,
-        fileLines,
-        lineNumber,
-        `# ${heading}`
-      );
+      this.insertLineInFile(file, fileLines, lineNumber, `# ${heading}`);
     }
   }
 
- /**
-  * Modified `file` by replacing the heading at `lineNumber` with `newHeading`,
-  * updating the heading style according the user settings.
-  *
-  * @param {TFile} file the file to modify
-  * @param {string[]} fileLines array of the file's contents, line by line
-  * @param {number} lineNumber zero-based index of the line to replace
-  * @param {HeadingStyle} oldStyle the style of the original heading
-  * @param {string} text the new text
-  */
+  /**
+   * Modified `file` by replacing the heading at `lineNumber` with `newHeading`,
+   * updating the heading style according the user settings.
+   *
+   * @param {TFile} file the file to modify
+   * @param {string[]} fileLines array of the file's contents, line by line
+   * @param {number} lineNumber zero-based index of the line to replace
+   * @param {HeadingStyle} oldStyle the style of the original heading
+   * @param {string} text the new text
+   */
   replaceHeading(
     file: TFile,
     fileLines: string[],
     lineNumber: number,
     oldStyle: HeadingStyle,
     newHeading: string,
-  ){
+  ) {
     const newStyle = this.settings.newHeadingStyle;
     const replaceStyle = this.settings.replaceStyle;
     // If we replace the style
@@ -378,35 +371,25 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
       // For underline style, replace heading line, then add underline if not
       // already there.
       if (newStyle === HeadingStyle.Underline) {
-        this.replaceLineInFile(
-          file,
-          fileLines,
-          lineNumber,
-          `${newHeading}`,
-        );
+        this.replaceLineInFile(file, fileLines, lineNumber, `${newHeading}`);
         if (oldStyle === HeadingStyle.Prefix) {
           this.insertLineInFile(
             file,
             fileLines,
-            lineNumber+1,
-            this.settings.underlineString
+            lineNumber + 1,
+            this.settings.underlineString,
           );
         }
       } else {
         // If not replacing style, match
         if (oldStyle === HeadingStyle.Underline) {
-          this.replaceLineInFile(
-            file,
-            fileLines,
-            lineNumber,
-            `${newHeading}`
-          );
+          this.replaceLineInFile(file, fileLines, lineNumber, `${newHeading}`);
         } else {
           this.replaceLineInFile(
             file,
             fileLines,
             lineNumber,
-            `# ${newHeading}`
+            `# ${newHeading}`,
           );
         }
       }
@@ -516,12 +499,10 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
 
     containerEl.createEl('h2', { text: 'Filename Heading Sync' });
     containerEl.createEl('p', {
-      text:
-        'This plugin will overwrite the first heading found in a file with the filename.',
+      text: 'This plugin will overwrite the first heading found in a file with the filename.',
     });
     containerEl.createEl('p', {
-      text:
-        'If no header is found, will insert a new one at the first line (after frontmatter).',
+      text: 'If no header is found, will insert a new one at the first line (after frontmatter).',
     });
 
     new Setting(containerEl)
@@ -596,17 +577,17 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
       )
       .addDropdown((cb) =>
         cb
-          .addOption(HeadingStyle.Prefix, "Prefix")
-          .addOption(HeadingStyle.Underline, "Underline")
+          .addOption(HeadingStyle.Prefix, 'Prefix')
+          .addOption(HeadingStyle.Underline, 'Underline')
           .setValue(this.plugin.settings.newHeadingStyle)
           .onChange(async (value) => {
-              if (value === "Prefix") {
-                this.plugin.settings.newHeadingStyle = HeadingStyle.Prefix;
-              }
-              if (value === "Underline") {
-                this.plugin.settings.newHeadingStyle = HeadingStyle.Underline;
-              }
-              await this.plugin.saveSettings();
+            if (value === 'Prefix') {
+              this.plugin.settings.newHeadingStyle = HeadingStyle.Prefix;
+            }
+            if (value === 'Underline') {
+              this.plugin.settings.newHeadingStyle = HeadingStyle.Underline;
+            }
+            await this.plugin.saveSettings();
           }),
       );
 
@@ -631,7 +612,7 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
       )
       .addText((text) =>
         text
-          .setPlaceholder("===")
+          .setPlaceholder('===')
           .setValue(this.plugin.settings.underlineString)
           .onChange(async (value) => {
             this.plugin.settings.underlineString = value;
@@ -649,8 +630,7 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
 
     containerEl.createEl('h2', { text: 'Manually Ignored Files' });
     containerEl.createEl('p', {
-      text:
-        'You can ignore files from this plugin by using the "ignore this file" command',
+      text: 'You can ignore files from this plugin by using the "ignore this file" command',
     });
 
     // go over all ignored files and add them

--- a/main.ts
+++ b/main.ts
@@ -333,7 +333,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
     heading: string,
   ) {
     const newStyle = this.settings.newHeadingStyle;
-    switch (newstyle) {
+    switch (newStyle) {
       case HeadingStyle.Underline: {
         this.insertLineInFile(file, fileLines, lineNumber, `${heading}`);
 
@@ -343,9 +343,11 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
           lineNumber + 1,
           this.settings.underlineString,
         );
+        break;
       }
       case HeadingStyle.Prefix: {
         this.insertLineInFile(file, fileLines, lineNumber, `# ${heading}`);
+        break;
       }
     }
   }
@@ -384,6 +386,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
                 lineNumber + 1,
                 this.settings.underlineString,
               );
+              break;
             }
             case HeadingStyle.Underline: {
               // Update underline with setting.
@@ -393,8 +396,10 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
                 lineNumber + 1,
                 this.settings.underlineString,
               );
+              break;
             }
           }
+          break;
         }
         // For prefix style, replace heading line, and possibly delete underline
         case HeadingStyle.Prefix: {
@@ -407,11 +412,14 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
           switch (oldStyle) {
             case HeadingStyle.Prefix: {
               // nop
+              break;
             }
             case HeadingStyle.Underline: {
               this.replaceLineInFile(file, fileLines, lineNumber + 1, '');
+              break;
             }
           }
+          break;
         }
       }
     } else {
@@ -419,6 +427,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
       switch (oldStyle) {
         case HeadingStyle.Underline: {
           this.replaceLineInFile(file, fileLines, lineNumber, `${newHeading}`);
+          break;
         }
         case HeadingStyle.Prefix: {
           this.replaceLineInFile(
@@ -427,6 +436,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
             lineNumber,
             `# ${newHeading}`,
           );
+          break;
         }
       }
     }

--- a/main.ts
+++ b/main.ts
@@ -330,25 +330,25 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
   ){
     const newStyle = this.settings.newHeadingStyle;
     if (newStyle === Underline) {
-        this.insertLineInFile(
-            file,
-            lines,
-            lineNumber,
-            `${heading}`,
-        );
-        this.insertLineInFile(
-            file,
-            lines,
-            lineNumber+1,
-            this.settings.underlineString;
-        );
+      this.insertLineInFile(
+        file,
+        lines,
+        lineNumber,
+        `${heading}`,
+      );
+      this.insertLineInFile(
+        file,
+        lines,
+        lineNumber+1,
+        this.settings.underlineString;
+      );
     } else {
-        this.insertLineInFile(
-            file,
-            lines,
-            lineNumber,
-            `# ${heading}`,
-        );
+      this.insertLineInFile(
+        file,
+        lines,
+        lineNumber,
+        `# ${heading}`,
+      );
     }
   }
 
@@ -373,41 +373,41 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
     const replaceStyle = this.settings.replaceStyle;
     // If we replace the style
     if (replaceStyle) {
-        // For underline style, replace heading line, then add underline if not
-        // already there.
-        if (newStyle === Underline) {
-            this.replaceLineInFile(
-                file,
-                lines,
-                lineNumber,
-                `${newHeading}`,
-            );
-            if (oldStyle === Prefix) {
-                this.insertLineInFile(
-                    file,
-                    lines,
-                    lineNumber+1,
-                    this.settings.underlineString;
-                );
-            }
-        } else {
-            // If not replacing style, match
-            if (oldStyle === Underline) {
-                this.replaceLineInFile(
-                    file,
-                    lines,
-                    lineNumber,
-                    `${newHeading}`,
-                );
-            } else {
-                this.replaceLineInFile(
-                    file,
-                    lines,
-                    lineNumber,
-                    `# ${newHeading}`,
-                );
-            }
+      // For underline style, replace heading line, then add underline if not
+      // already there.
+      if (newStyle === Underline) {
+        this.replaceLineInFile(
+          file,
+          lines,
+          lineNumber,
+          `${newHeading}`,
+        );
+        if (oldStyle === Prefix) {
+          this.insertLineInFile(
+            file,
+            lines,
+            lineNumber+1,
+            this.settings.underlineString;
+          );
         }
+      } else {
+        // If not replacing style, match
+        if (oldStyle === Underline) {
+          this.replaceLineInFile(
+            file,
+            lines,
+            lineNumber,
+            `${newHeading}`,
+          );
+        } else {
+          this.replaceLineInFile(
+            file,
+            lines,
+            lineNumber,
+            `# ${newHeading}`,
+          );
+        }
+      }
     }
   }
 
@@ -607,34 +607,34 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
           }),
       );
 
-      new Setting(containerEl)
-          .setName('Replace Heading Style')
-          .setDesc(
-              'Whether this plugin should replace existing heading styles when updating headings.',
-          )
-          .addToggle((toggle) =>
-              toggle
-                  .setValue(this.plugin.settings.replaceStyle)
-                  .onChange(async (value) => {
-                      this.plugin.settings.replaceStyle = value;
-                      await this.plugin.saveSettings();
-                  }),
-          );
+    new Setting(containerEl)
+      .setName('Replace Heading Style')
+      .setDesc(
+        'Whether this plugin should replace existing heading styles when updating headings.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.replaceStyle)
+          .onChange(async (value) => {
+            this.plugin.settings.replaceStyle = value;
+            await this.plugin.saveSettings();
+          }),
+      );
 
-      new Setting(containerEl)
-          .setName('Underline String')
-          .setDesc(
-              'The string to use when insert Underline-style headings; should be some number of "="s.',
-          )
-          .addText((text) =>
-              text
-                .setPlaceHolder("===")
-                .setValue(this.plugin.settings.underlineString)
-                .onChange(async (value) => {
-                  this.plugin.settings.underlineString = value;
-                  await this.plugin.saveSettings();
-                }),
-         );
+    new Setting(containerEl)
+      .setName('Underline String')
+      .setDesc(
+        'The string to use when insert Underline-style headings; should be some number of "="s.',
+      )
+      .addText((text) =>
+        text
+          .setPlaceHolder("===")
+          .setValue(this.plugin.settings.underlineString)
+          .onChange(async (value) => {
+            this.plugin.settings.underlineString = value;
+            await this.plugin.saveSettings();
+          }),
+      );
 
     containerEl.createEl('h2', { text: 'Ignored Files By Regex' });
     containerEl.createEl('p', {

--- a/main.ts
+++ b/main.ts
@@ -592,7 +592,7 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('New Heading Style')
       .setDesc(
-        'Which Markdown heading style to use when creating new headings: Prefix ("# Heading") or Underline ("Heading\n===").',
+        'Which Markdown heading style to use when creating new headings: Prefix ("# Heading") or Underline ("Heading\\n===").',
       )
       .addDropdown((cb) =>
         cb

--- a/main.ts
+++ b/main.ts
@@ -333,18 +333,20 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
     heading: string,
   ) {
     const newStyle = this.settings.newHeadingStyle;
-    if (newStyle === HeadingStyle.Underline) {
-      this.insertLineInFile(file, fileLines, lineNumber, `${heading}`);
+    switch (newstyle){
+      case HeadingStyle.Underline: {
+        this.insertLineInFile(file, fileLines, lineNumber, `${heading}`);
 
-      this.insertLineInFile(
-        file,
-        fileLines,
-        lineNumber + 1,
-        this.settings.underlineString,
-      );
-    } else {
-      this.insertLineInFile(file, fileLines, lineNumber, `# ${heading}`);
-    }
+        this.insertLineInFile(
+          file,
+          fileLines,
+          lineNumber + 1,
+          this.settings.underlineString,
+        );
+      }
+      case HeadingStyle.Prefix: {
+        this.insertLineInFile(file, fileLines, lineNumber, `# ${heading}`);
+      }
   }
 
   /**
@@ -366,33 +368,53 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
   ) {
     const newStyle = this.settings.newHeadingStyle;
     const replaceStyle = this.settings.replaceStyle;
-    // If we replace the style
+    // If replacing the style
     if (replaceStyle) {
-      // For underline style, replace heading line, then add underline if not
-      // already there.
-      if (newStyle === HeadingStyle.Underline) {
-        this.replaceLineInFile(file, fileLines, lineNumber, `${newHeading}`);
-        if (oldStyle === HeadingStyle.Prefix) {
-          this.insertLineInFile(
-            file,
-            fileLines,
-            lineNumber + 1,
-            this.settings.underlineString,
-          );
-        } else {
-          // Update underline with setting.
-          this.replaceLineInFile(
-            file,
-            fileLines,
-            lineNumber + 1,
-            this.settings.underlineString,
-          );
-        }
-      } else {
-        // If not replacing style, match
-        if (oldStyle === HeadingStyle.Underline) {
+      switch (newStyle) {
+        // For underline style, replace heading line...
+        case HeadingStyle.Underline: {
           this.replaceLineInFile(file, fileLines, lineNumber, `${newHeading}`);
-        } else {
+          //..., then add or replace underline.
+          switch(oldStyle) {
+            case HeadingStyle.Prefix: {
+              this.insertLineInFile(
+                file,
+                fileLines,
+                lineNumber + 1,
+                this.settings.underlineString,
+              );
+            }
+            case HeadingStyle.Underline: {
+              // Update underline with setting.
+              this.replaceLineInFile(
+                file,
+                fileLines,
+                lineNumber + 1,
+                this.settings.underlineString,
+              );
+            }
+          }
+        }
+        // For prefix style, replace heading line, and possibly delete underline
+        case HeadingStyle.Prefix: {
+          this.replaceLineInFile(file, fileLines, lineNumber, `# ${newHeading}`);
+          switch (oldStyle) {
+            case HeadingStyle.Prefix: {
+              // nop
+            }
+            case HeadingStyle.Underline: {
+              this.replaceLineInFile(file, fileLines, lineNumber+1, '');
+            }
+          }
+        }
+      }
+    } else {
+      // If not replacing style, match
+      switch (oldStyle) {
+        case HeadingStyle.Underline: {
+          this.replaceLineInFile(file, fileLines, lineNumber, `${newHeading}`);
+        }
+        case HeadingStyle.Prefix: {
           this.replaceLineInFile(
             file,
             fileLines,

--- a/main.ts
+++ b/main.ts
@@ -12,9 +12,10 @@ import { isExcluded } from './exclusions';
 
 const stockIllegalSymbols = /[\\/:|#^[\]]/g;
 
+// Must be Strings unless settings dialog is updated.
 const enum HeadingStyle {
-    Prefix,
-    Underline,
+    Prefix = "Prefix",
+    Underline = "Underline",
 }
 
 interface LinePointer {
@@ -593,9 +594,10 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
       .setDesc(
         'Which Markdown heading style to use when creating new headings: Prefix ("# Heading") or Underline ("Heading\n===").',
       )
-      .addText((text) =>
-        text
-          .setPlaceHolder("Prefix|Underline")
+      .addDropdown((cb) =>
+        cb
+          .addOption(HeadingStyle.Prefix, "Prefix")
+          .addOption(HeadingStyle.Underline, "Underline")
           .setValue(this.plugin.settings.newHeadingStyle)
           .onChange(async (value) => {
               if (value === "Prefix") {

--- a/main.ts
+++ b/main.ts
@@ -379,6 +379,14 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
             lineNumber + 1,
             this.settings.underlineString,
           );
+        } else {
+          // Update underline with setting.
+          this.replaceLineInFile(
+            file,
+            fileLines,
+            lineNumber + 1,
+            this.settings.underlineString,
+          );
         }
       } else {
         // If not replacing style, match

--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,7 @@ import { isExcluded } from './exclusions';
 
 const stockIllegalSymbols = /[\\/:|#^[\]]/g;
 
-enum HeadingStyle {
+const enum HeadingStyle {
     Prefix,
     Underline,
 }
@@ -40,7 +40,7 @@ const DEFAULT_SETTINGS: FilenameHeadingSyncPluginSettings = {
   ignoreRegex: '',
   useFileOpenHook: true,
   useFileSaveHook: true,
-  newHeadingStyle: Prefix,
+  newHeadingStyle: HeadingStyle.Prefix,
   replaceStyle: false,
   underlineString: "===";
 };
@@ -280,14 +280,14 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
         return {
           lineNumber: i,
           text: fileLines[i].substring(2),
-          style: Prefix,
+          style: HeadingStyle.Prefix,
         };
       } else {
           if (fileLines[i+1].match(/^=+$/) !== null) {
             return {
               lineNumber: i,
               text: fileLines[i],
-              style: Underline,
+              style: HeadingStyle.Underline,
             }
           }
       }
@@ -382,7 +382,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
           lineNumber,
           `${newHeading}`,
         );
-        if (oldStyle === Prefix) {
+        if (oldStyle === HeadingStyle.Prefix) {
           this.insertLineInFile(
             file,
             lines,
@@ -392,7 +392,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
         }
       } else {
         // If not replacing style, match
-        if (oldStyle === Underline) {
+        if (oldStyle === HeadingStyle.Underline) {
           this.replaceLineInFile(
             file,
             lines,
@@ -598,10 +598,10 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
           .setValue(this.plugin.settings.newHeadingStyle)
           .onChange(async (value) => {
               if (value === "Prefix") {
-                this.plugin.settings.newHeadingStyle = Prefix;
+                this.plugin.settings.newHeadingStyle = HeadingStyle.Prefix;
               }
               if (value === "Underline") {
-                this.plugin.settings.newHeadingStyle = Underline;
+                this.plugin.settings.newHeadingStyle = HeadingStyle.Underline;
               }
               await this.plugin.saveSettings();
           }),

--- a/main.ts
+++ b/main.ts
@@ -42,7 +42,7 @@ const DEFAULT_SETTINGS: FilenameHeadingSyncPluginSettings = {
   useFileSaveHook: true,
   newHeadingStyle: HeadingStyle.Prefix,
   replaceStyle: false,
-  underlineString: "===";
+  underlineString: "===",
 };
 
 export default class FilenameHeadingSyncPlugin extends Plugin {
@@ -283,7 +283,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
           style: HeadingStyle.Prefix,
         };
       } else {
-          if (fileLines[i+1].match(/^=+$/) !== null) {
+          if (fileLines[i+1] !== undefined && fileLines[i+1].match(/^=+$/) !== null) {
             return {
               lineNumber: i,
               text: fileLines[i],
@@ -329,25 +329,26 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
     heading: string,
   ){
     const newStyle = this.settings.newHeadingStyle;
-    if (newStyle === Underline) {
+    if (newStyle === HeadingStyle.Underline) {
       this.insertLineInFile(
         file,
-        lines,
+        fileLines,
         lineNumber,
-        `${heading}`,
+        `${heading}`
       );
+
       this.insertLineInFile(
         file,
-        lines,
+        fileLines,
         lineNumber+1,
-        this.settings.underlineString;
+        this.settings.underlineString
       );
     } else {
       this.insertLineInFile(
         file,
-        lines,
+        fileLines,
         lineNumber,
-        `# ${heading}`,
+        `# ${heading}`
       );
     }
   }
@@ -375,19 +376,19 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
     if (replaceStyle) {
       // For underline style, replace heading line, then add underline if not
       // already there.
-      if (newStyle === Underline) {
+      if (newStyle === HeadingStyle.Underline) {
         this.replaceLineInFile(
           file,
-          lines,
+          fileLines,
           lineNumber,
           `${newHeading}`,
         );
         if (oldStyle === HeadingStyle.Prefix) {
           this.insertLineInFile(
             file,
-            lines,
+            fileLines,
             lineNumber+1,
-            this.settings.underlineString;
+            this.settings.underlineString
           );
         }
       } else {
@@ -395,16 +396,16 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
         if (oldStyle === HeadingStyle.Underline) {
           this.replaceLineInFile(
             file,
-            lines,
+            fileLines,
             lineNumber,
-            `${newHeading}`,
+            `${newHeading}`
           );
         } else {
           this.replaceLineInFile(
             file,
-            lines,
+            fileLines,
             lineNumber,
-            `# ${newHeading}`,
+            `# ${newHeading}`
           );
         }
       }
@@ -628,7 +629,7 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
       )
       .addText((text) =>
         text
-          .setPlaceHolder("===")
+          .setPlaceholder("===")
           .setValue(this.plugin.settings.underlineString)
           .onChange(async (value) => {
             this.plugin.settings.underlineString = value;

--- a/main.ts
+++ b/main.ts
@@ -333,7 +333,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
     heading: string,
   ) {
     const newStyle = this.settings.newHeadingStyle;
-    switch (newstyle){
+    switch (newstyle) {
       case HeadingStyle.Underline: {
         this.insertLineInFile(file, fileLines, lineNumber, `${heading}`);
 
@@ -347,6 +347,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
       case HeadingStyle.Prefix: {
         this.insertLineInFile(file, fileLines, lineNumber, `# ${heading}`);
       }
+    }
   }
 
   /**
@@ -375,7 +376,7 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
         case HeadingStyle.Underline: {
           this.replaceLineInFile(file, fileLines, lineNumber, `${newHeading}`);
           //..., then add or replace underline.
-          switch(oldStyle) {
+          switch (oldStyle) {
             case HeadingStyle.Prefix: {
               this.insertLineInFile(
                 file,
@@ -397,13 +398,18 @@ export default class FilenameHeadingSyncPlugin extends Plugin {
         }
         // For prefix style, replace heading line, and possibly delete underline
         case HeadingStyle.Prefix: {
-          this.replaceLineInFile(file, fileLines, lineNumber, `# ${newHeading}`);
+          this.replaceLineInFile(
+            file,
+            fileLines,
+            lineNumber,
+            `# ${newHeading}`,
+          );
           switch (oldStyle) {
             case HeadingStyle.Prefix: {
               // nop
             }
             case HeadingStyle.Underline: {
-              this.replaceLineInFile(file, fileLines, lineNumber+1, '');
+              this.replaceLineInFile(file, fileLines, lineNumber + 1, '');
             }
           }
         }
@@ -529,10 +535,12 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
 
     containerEl.createEl('h2', { text: 'Filename Heading Sync' });
     containerEl.createEl('p', {
-      text: 'This plugin will overwrite the first heading found in a file with the filename.',
+      text:
+        'This plugin will overwrite the first heading found in a file with the filename.',
     });
     containerEl.createEl('p', {
-      text: 'If no header is found, will insert a new one at the first line (after frontmatter).',
+      text:
+        'If no header is found, will insert a new one at the first line (after frontmatter).',
     });
 
     new Setting(containerEl)
@@ -660,7 +668,8 @@ class FilenameHeadingSyncSettingTab extends PluginSettingTab {
 
     containerEl.createEl('h2', { text: 'Manually Ignored Files' });
     containerEl.createEl('p', {
-      text: 'You can ignore files from this plugin by using the "ignore this file" command',
+      text:
+        'You can ignore files from this plugin by using the "ignore this file" command',
     });
 
     // go over all ignored files and add them


### PR DESCRIPTION
Fixes #72 

Comes with lots of options:
<img width="771" alt="image" src="https://github.com/dvcrn/obsidian-filename-heading-sync/assets/1133598/cadf9091-ef4a-499b-9685-1e11b06fbd03">

The defaults retain the old behaviour.

This is my first TypeScript in a while and my first Obsidian plugin so let me know if I did something stupid.