### PR TITLE
Add support for date-prefixed filenames

### DIFF
--- a/main.test.ts
+++ b/main.test.ts
@@ -30,6 +30,21 @@ describe('FilenameHeadingSyncPlugin', () => {
     };
 
     plugin = new FilenameHeadingSyncPlugin(app, manifest);
+
+    // Initialize settings with default values
+    plugin.settings = {
+      userIllegalSymbols: [],
+      ignoredFiles: {},
+      ignoreRegex: '',
+      useFileOpenHook: true,
+      useFileSaveHook: true,
+      newHeadingStyle: 'Prefix' as any,
+      replaceStyle: false,
+      underlineString: '===',
+      renameDebounceTimeout: 1000,
+      insertHeadingIfMissing: true,
+      ignoreFilenamePrefix: 0,
+    };
   });
 
   describe('findHeading', () => {
@@ -132,6 +147,52 @@ describe('FilenameHeadingSyncPlugin', () => {
       expect(result?.text).toBe('Actual Heading');
       expect(result?.style).toBe('Prefix');
       expect(result?.lineNumber).toBe(4);
+    });
+  });
+
+  describe('extractTitleFromFilename', () => {
+    it('should return full filename when ignoreFilenamePrefix is 0', () => {
+      plugin.settings.ignoreFilenamePrefix = 0;
+      const result = plugin.extractTitleFromFilename('202409261558 My Document');
+      expect(result).toBe('202409261558 My Document');
+    });
+
+    it('should extract title after date prefix', () => {
+      plugin.settings.ignoreFilenamePrefix = 13; // "202409261558 " is 13 characters
+      const result = plugin.extractTitleFromFilename('202409261558 My Document');
+      expect(result).toBe('My Document');
+    });
+
+    it('should handle space after prefix correctly', () => {
+      plugin.settings.ignoreFilenamePrefix = 12; // "202409261558" is 12 characters
+      const result = plugin.extractTitleFromFilename('202409261558 My Document');
+      expect(result).toBe('My Document');
+    });
+
+    it('should handle no space after prefix', () => {
+      plugin.settings.ignoreFilenamePrefix = 12; // "202409261558" is 12 characters
+      const result = plugin.extractTitleFromFilename('202409261558My Document');
+      expect(result).toBe('My Document');
+    });
+  });
+
+  describe('createFilenameWithPrefix', () => {
+    it('should return heading when ignoreFilenamePrefix is 0', () => {
+      plugin.settings.ignoreFilenamePrefix = 0;
+      const result = plugin.createFilenameWithPrefix('My Document', '202409261558 Old Title');
+      expect(result).toBe('My Document');
+    });
+
+    it('should preserve prefix when creating new filename', () => {
+      plugin.settings.ignoreFilenamePrefix = 13; // "202409261558 " is 13 characters
+      const result = plugin.createFilenameWithPrefix('My Document', '202409261558 Old Title');
+      expect(result).toBe('202409261558 My Document');
+    });
+
+    it('should handle different prefix lengths', () => {
+      plugin.settings.ignoreFilenamePrefix = 8; // "20240926" is 8 characters
+      const result = plugin.createFilenameWithPrefix('My Document', '20240926 Old Title');
+      expect(result).toBe('20240926 My Document');
     });
   });
 });


### PR DESCRIPTION
## Add support for date-prefixed filenames

### Problem
Users with automatic date-stamped filenames (e.g., "202409261558 My Document") want to sync only the title part to headings, not the entire filename including the date.

### Solution
- Add `ignoreFilenamePrefix` setting to specify how many characters to ignore from the beginning of filenames
- Update sync logic to strip date prefixes when creating headings
- Preserve date prefixes when renaming files from headings
- Add comprehensive tests for the new functionality

### Usage
1. Set "Ignore Filename Prefix Characters" to `13` (for "202409261558 ")
2. Filename: `202409261558 My Document` → Heading: `# My Document`
3. When heading changes to "New Title" → Filename: `202409261558 New Title`

### Testing
- All existing tests pass
- New tests cover date prefix functionality
- Build completes successfully